### PR TITLE
Ignore guest customers.

### DIFF
--- a/stripe_datev/charges.py
+++ b/stripe_datev/charges.py
@@ -60,9 +60,13 @@ def createRevenueItems(charges):
                 continue
             else:
                 raise NotImplementedError("Handling of partially refunded charges is not implemented yet")
-        
+
         if "in_" in getChargeDescription(charge):
             print("Skipping charge referencing invoice", charge.id, charge.description)
+            continue
+
+        if charge.customer == None:
+            print("Skipping charge with empty customer field/guest account", charge.id)
             continue
 
         cus = customer.retrieveCustomer(charge.customer)
@@ -112,6 +116,8 @@ def createAccountingRecords(charges):
   records = []
 
   for charge in charges:
+    if charge.customer == None:
+       continue
     acc_props = customer.getAccountingProps(customer.retrieveCustomer(charge.customer))
     created = datetime.fromtimestamp(charge.created, timezone.utc).astimezone(config.accounting_tz)
 


### PR DESCRIPTION
Workaround for this crash:

```
Traceback (most recent call last):
  File "/Users/daniel/code/ttt/Stripe2Datev-multi/stripe-datev-cli.py", line 249, in <module>
    StripeDatevCli().run(sys.argv)
  File "/Users/daniel/code/ttt/Stripe2Datev-multi/stripe-datev-cli.py", line 49, in run
    getattr(self, args.command)(argv[2:])
  File "/Users/daniel/code/ttt/Stripe2Datev-multi/stripe-datev-cli.py", line 79, in download
    revenue_items += stripe_datev.charges.createRevenueItems(direct_charges)
  File "/Users/daniel/code/ttt/Stripe2Datev-multi/stripe_datev/charges.py", line 68, in createRevenueItems
    cus = customer.retrieveCustomer(charge.customer)
  File "/Users/daniel/code/ttt/Stripe2Datev-multi/stripe_datev/customer.py", line 20, in retrieveCustomer
    raise Exception("Unexpected retrieveCustomer() argument: {}".format(id))
Exception: Unexpected retrieveCustomer() argument: None
```

which happens if a charge has no customer, but is made with a Stripe guest account: https://stripe.com/docs/payments/checkout/guest-customers

This should be fixed properly, maybe just a simple custom guest struct that shares an interface with charge.customer.